### PR TITLE
Feature/refactor

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,5 @@
 [
-	{ "keys": ["super+shift+c"], "command": "phpcoverage_update_all" }
+	{ "keys": ["super+shift+c"], "command": "phpcoverage_update" },
+    { "keys": ["super+alt+shift+c"], "command": "phpcoverage_clear_markers" },
+    { "keys": ["super+shift+g"], "command": "phpcoverage_generate_report" }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,3 @@
 [
-	{ "keys": ["super+shift+c"], "command": "show_php_coverage" }
+	{ "keys": ["super+shift+c"], "command": "phpcoverage_update_all" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,7 +9,9 @@
             "children":
             [
                 {"caption":"Update All", "command": "phpcoverage_update_all" },
-                {"caption":"Update Current File", "command": "phpcoverage_update" }
+                {"caption":"Update Current File", "command": "phpcoverage_update" },
+                {"caption":"Clear All File Markers", "command": "phpcoverage_clear_markers" },
+                {"caption":"Generate Coverage Report", "command": "phpcoverage_generate_report" }
             ]
         }
     ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,17 @@
+[
+{
+    "id": "tools",
+    "children":
+    [
+        {
+            "id": "phpcoverage",
+            "caption": "PHP Coverage",
+            "children":
+            [
+                {"caption":"Update All", "command": "phpcoverage_update_all" },
+                {"caption":"Update Current File", "command": "phpcoverage_update" }
+            ]
+        }
+    ]
+}
+]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-SublimePHPCoverage
-==================
+# Sublime Text PHP Coverage Package
 
 A plugin for Sublime Text 2, which visualises PHP code coverage data in
 the editor.
@@ -14,26 +13,38 @@ do this with git:
 $ git clone git://github.com/bradfeehan/SublimePHPCoverage.git "~/Library/Application Support/Sublime Text 2/Packages/SublimePHPCoverage"
 ```
 
+## Configuration
+
+For some this package will work out of the box, but you'll most likely find
+something that you want to customize. The `phpcoverage.sublime-settings` file
+has been annotated with examples of common configurations.  Any of the default
+settings can be overridden via the user configuration file.
+
+Additionally, settings may be set on a per-project basis in the `.sublime-project`
+file. This is especially useful for setting the path to the clover report as it may differ for each project. To override a setting in a project simply add the key to the `.sublime-project`
+settings object, prepended with `phpcoverage_`. For instance, to override
+`path_report` you would set `phpcoverage_path_report` to your `.sublime-project`
+file.
 
 ## Setting up PHPUnit
 
 Make sure PHPUnit is configured to output code coverage data to
-`tests/coverage/clover.xml` (relative to your Sublime Text 2 project
+`build/log/clover.xml` (relative to your Sublime Text 2 project
 root), in Clover format. You can do this with PHPUnit's
 [command-line arguments][1]:
 
 ```bash
-~/myProject$ phpunit --coverage-clover tests/coverage/clover.xml
+~/myProject$ phpunit --coverage-clover build/log/clover.xml
 ```
 
-...or in PHPUnit's [XML configuration file][2]:
+...or, preferably, in PHPUnit's [XML configuration file][2]:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit>
 	<!-- ... -->
 	<logging>
-		<log type="coverage-clover" target="tests/coverage/clover.xml" />
+		<log type="coverage-clover" target="build/log/clover.xml" />
 	</logging>
 	<!-- ... -->
 </phpunit>
@@ -50,31 +61,33 @@ displayed in the margin, with a summary in the status bar:
 Green lines are covered, red are not covered, and non-annotated lines
 aren't executable (not counted in code coverage data).
 
-### Manually triggering a refresh
+### Hands-Free Mode
+
+Out of the box, every time a PHP file is saved phpunit will be run and
+the file markers will be updated.  This will provide you live code coverage
+information as you work. In larger projects this may be undesirable as
+the time to generate a new report may be significant.  If this is the case
+for your project, simply set `coverage_update_on_save` to `false`.
+
+### Manually Triggering a Refresh
 
 You can hit ⌘⇧C to trigger a refresh of the code coverage data for the
 currently focused view (tab).
 
-The pluginalse  adds an "phpcoverage_update" command, which can be
-used to refresh the code coverage data for all open files. This command
-can be called in a variety of ways, e.g. from the command line:
+You may also hit ⌘⇧G to trigger the generation of a new clover report.
 
-```bash
-$ subl --command phpcoverage_update
-```
-
-This is handy to include after running PHPUnit in a script, as it'll
-automatically refresh the information shown in Sublime with the new
-code coverage (which is almost certainly what you want, at least until
-I add some support for detecting changes to the code coverage file and
-updating the display automatically... Pull Requests accepted!)
-
+These options are also available under "PHP Coverage" in the "Tools" menu.
 
 ## Troubleshooting
 
-Check the code coverage file is present and has a `<file>` element
-for the file in question. Also look in Sublime's console (accessible
+Check that the code coverage file is present and that it has a `<file>`
+element for the file in question. Also look in Sublime's console (accessible
 via <code>Ctrl + `</code>).
+
+If `coverage_update_on_save` is set to `true` and new reports are not being
+generated your system may require that you specify the full system path to
+phpunit or the coverage report generator of your choice in
+`coverage_update_command`.
 
 [1]: <http://www.phpunit.de/manual/current/en/textui.html#textui.clioptions> "PHPUnit Command-Line Switches"
 [2]: <http://www.phpunit.de/manual/current/en/appendixes.configuration.html> "PHPUnit XML Configuration File"

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ aren't executable (not counted in code coverage data).
 You can hit ⌘⇧C to trigger a refresh of the code coverage data for the
 currently focused view (tab).
 
-The pluginalse  adds an "update_php_coverage" command, which can be
+The pluginalse  adds an "phpcoverage_update" command, which can be
 used to refresh the code coverage data for all open files. This command
 can be called in a variety of ways, e.g. from the command line:
 
 ```bash
-$ subl --command update_php_coverage
+$ subl --command phpcoverage_update
 ```
 
 This is handy to include after running PHPUnit in a script, as it'll

--- a/SublimePHPCoverage.py
+++ b/SublimePHPCoverage.py
@@ -1,30 +1,66 @@
 import os
 import sublime
 import sublime_plugin
+import subprocess
 import xml.etree.ElementTree as ET
 
 
 def find_project_root(file_path):
     """Project root is defined as the parent directory that contains a
-    directory called 'tests/coverage'"""
-    if os.access(os.path.join(file_path, 'tests/coverage'), os.R_OK):
+    directory matching setting path_report'"""
+    if os.access(os.path.join(file_path, Var.get('path_report')), os.R_OK):
         return file_path
 
     parent, current = os.path.split(file_path)
     if current:
         return find_project_root(parent)
 
+class Var:
+    @staticmethod
+    def get(key):
+        settings_project = sublime.active_window().active_view().settings()
+        settings_file = sublime.load_settings('phpcoverage.sublime-settings')
+        return settings_project.get('phpcoverage_' + key, settings_file.get(key))
 
-class SublimePHPCoverageListener(sublime_plugin.EventListener):
-    """Event listener to highlight uncovered lines when a PHP file is
-    loaded"""
+    @staticmethod
+    def path_project():
+        return find_project_root(sublime.active_window().active_view().file_name())
 
-    def on_load(self, view):
-        if 'source.php' not in view.scope_name(0):
-            return
+def clear_markers(view):
+    view.erase_status('SublimePHPCoverageBad')
+    view.erase_status('SublimePHPCoverageGood')
+    view.erase_regions('SublimePHPCoverageBad')
+    view.erase_regions('SublimePHPCoverageGood')
+    view.set_status('SublimePHPCoveragePercentage', '')
 
-        view.run_command('phpcoverage_update')
+def debug_message(msg):
+    if bool(Var.get('debug')) == True:
+        print("[PHP Coverage] " + str(msg))
 
+def shell_exec(cmd):
+    debug_message('$ ' + cmd)
+
+    info = None
+    if os.name == 'nt':
+        info = subprocess.STARTUPINFO()
+        info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        info.wShowWindow = subprocess.SW_HIDE
+
+    cwd = Var.path_project()
+    debug_message("cwd: " + cwd)
+
+    proc = subprocess.Popen([cmd], stdout=subprocess.PIPE, startupinfo=info, cwd=cwd)
+    if proc.stdout:
+        debug_message(proc.communicate()[0].decode())
+    return proc
+
+class PhpcoverageClearMarkersCommand(sublime_plugin.ApplicationCommand):
+    """Clear markers in any currently open files."""
+
+    def run(self):
+        for window in sublime.windows():
+            for view in window.views():
+                clear_markers(view)
 
 class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
     """Highlight uncovered lines in the current file based on a previous
@@ -32,38 +68,38 @@ class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         view = self.view
-
-        # clean up
-        view.erase_status('SublimePHPCoverageBad')
-        view.erase_status('SublimePHPCoverageGood')
-        view.erase_regions('SublimePHPCoverageBad')
-        view.erase_regions('SublimePHPCoverageGood')
-        view.set_status('SublimePHPCoveragePercentage', '')
+        clear_markers(view)
 
         filename = view.file_name()
-        print 'SublimePHPCoverage: Filename: %s' % filename
+        debug_message('File: %s' % filename)
 
         # don't run for unsaved files
         if not filename:
-            print 'SublimePHPCoverage: Not running for unsaved file'
+            debug_message('Cannot run on unsaved file "' + filename + '".')
+            return
+
+        ext = os.path.splitext(filename)[1][1:].strip()
+        ext_match = ext in Var.get('extensions')
+        if ext_match != True:
+            debug_message('Skipping file, filename does not match extensions array.')
             return
 
         project_root = find_project_root(filename)
         if not project_root:
-            print 'SublimePHPCoverage: Could not find coverage directory.'
+            debug_message('Clover file not found (' + Var.get('path_report') + ').')
             return
 
         good = []
         bad = []
 
-        coverage = os.path.join(project_root, 'tests/coverage/clover.xml')
+        coverage = os.path.join(project_root, Var.get('path_report'))
         root = ET.parse(coverage)
 
         for php_file in root.findall('./project//file'):
             if php_file.get('name') == filename:
                 metrics = php_file.find('./metrics')
                 loc = int(metrics.get('loc'))
-                print 'SublimePHPCoverage: lines of code: %s' % loc
+                debug_message('Lines of code: %s' % loc)
                 for line in php_file.findall('line'):
                     # skip non-statement lines
                     if line.get('type') != 'stmt':
@@ -88,7 +124,7 @@ class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
                 total = int(metrics.get('statements'))
                 percentage = 100 * covered / float(total)
                 coverage = '%d/%d lines (%.2f%%)' % (covered, total, percentage)
-                print 'Code coverage: %s' % coverage
+                debug_message('Code coverage: %s' % coverage)
                 view.set_status('SublimePHPCoveragePercentage', 'Code coverage: %s' % coverage)
                 break
 
@@ -98,7 +134,6 @@ class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
         if good:
             view.add_regions('SublimePHPCoverageBad', good, 'markup.inserted', 'dot', sublime.HIDDEN)
 
-
 class PhpcoverageUpdateAllCommand(sublime_plugin.ApplicationCommand):
     """Update code coverage highlights in any currently open files."""
 
@@ -106,3 +141,24 @@ class PhpcoverageUpdateAllCommand(sublime_plugin.ApplicationCommand):
         for window in sublime.windows():
             for view in window.views():
                 view.run_command('phpcoverage_update')
+
+class PhpcoverageGenerateReport(sublime_plugin.ApplicationCommand):
+    """Update code coverage report."""
+
+    def run(self):
+        debug_message('Generating code coverage report.')
+        shell_exec(Var.get('coverage_update_command'))
+
+class PhpcoverageEventListener(sublime_plugin.EventListener):
+    """Event listener for the plugin"""
+    def on_post_save(self, view):
+        debug_message('Event: Post-Save')
+        if bool(Var.get('coverage_update_on_save')) == True:
+            sublime.run_command('phpcoverage_generate_report')
+        if bool(Var.get('markers_update_on_save')) == True:
+            sublime.run_command('phpcoverage_update_all')
+
+    def on_load(self, view):
+        if 'source.php' not in view.scope_name(0):
+            return
+        view.run_command('phpcoverage_update')

--- a/SublimePHPCoverage.py
+++ b/SublimePHPCoverage.py
@@ -23,10 +23,10 @@ class SublimePHPCoverageListener(sublime_plugin.EventListener):
         if 'source.php' not in view.scope_name(0):
             return
 
-        view.run_command('show_php_coverage')
+        view.run_command('phpcoverage_update')
 
 
-class ShowPhpCoverageCommand(sublime_plugin.TextCommand):
+class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
     """Highlight uncovered lines in the current file based on a previous
     coverage run."""
 
@@ -99,10 +99,10 @@ class ShowPhpCoverageCommand(sublime_plugin.TextCommand):
             view.add_regions('SublimePHPCoverageBad', good, 'markup.inserted', 'dot', sublime.HIDDEN)
 
 
-class UpdatePhpCoverageCommand(sublime_plugin.ApplicationCommand):
+class PhpcoverageUpdateAllCommand(sublime_plugin.ApplicationCommand):
     """Update code coverage highlights in any currently open files."""
 
     def run(self):
         for window in sublime.windows():
             for view in window.views():
-                view.run_command('show_php_coverage')
+                view.run_command('phpcoverage_update')

--- a/phpcoverage.sublime-settings
+++ b/phpcoverage.sublime-settings
@@ -1,0 +1,64 @@
+{
+    /**
+     * PHP COVERAGE
+     * Settings
+     */
+
+    /**
+     * Show debugging info in the console?
+     *
+     * DEFAULT: false
+     */
+    "debug": false,
+
+    /**
+     * Update markers to match report on every save?
+     *
+     * DEFAULT: true
+     */
+    "markers_update_on_save": true,
+
+    /**
+     * Extensions for which PHP coverage will be updated
+     *
+     * DEFAULT: ["php"]
+     */
+    "extensions": ["php"],
+
+    /**
+     * Trigger coverage report on every save?
+     *
+     * DEFAULT: true
+     */
+    "coverage_update_on_save": true,
+
+    /**
+     * Command to trigger update of coverage report
+     *
+     * DEFAULT: "phpunit"
+     *
+     * As long as you have phpunit installed globally and clover logging
+     * configured in your configuration file, the default should work:
+     *
+     *     "coverage_update_command": "phpunit",
+     *
+     * In some cases it may be necessary to specify a full path to the
+     * executable as the value:
+     *
+     *     "coverage_update_command": "/usr/local/bin/phpunit",
+     *
+     * If you prefer not to create a configuration file you may specify
+     * the full command as the value:
+     *
+     *     "coverage_update_command": "phpunit --coverage-clover=.tmp/clover.xml",
+     */
+    "coverage_update_command": "phpunit",
+
+    /**
+     * Path to the directory clover-formatted coverage report
+     *
+     * DEFAULT: "build/logs"
+     */
+    "path_report": "build/logs/clover.xml"
+
+}


### PR DESCRIPTION
Significant refactoring of the codebase.
Fixes issues #1 and #2. Addresses #3 in a roundabout way.

Usually I wouldn't lump so many commits together, but switching to a settings-based configuration proved to be rather involved.
- Added new default behavior to update markers on file save.
- Added new default behavior to run code coverage report on save. Addresses #3, but may be a stopgap.
- Settings files now utilized instead of hard coded values. Fixes #1.
- Settings may be overridden by a .sublime-project file. Fixes #1.
- Added menu option and keyboard shortcut to toggle off markers. Fixes #2.
- Added menu options for updating markers and generating coverage reports.
- Debug messages are now toggled on and off in settings.
- Debug messages are now handled by a common function.
- Only handles extensions defined in the settings file, .php only by default.
