### PR TITLE
Normalize file paths before comparison (Update SublimePHPCoverage.py)

### DIFF
--- a/SublimePHPCoverage.py
+++ b/SublimePHPCoverage.py
@@ -96,7 +96,7 @@ class PhpcoverageUpdateCommand(sublime_plugin.TextCommand):
         root = ET.parse(coverage)
 
         for php_file in root.findall('./project//file'):
-            if php_file.get('name') == filename:
+            if os.path.realpath(php_file.get('name')) == os.path.realpath(filename):
                 metrics = php_file.find('./metrics')
                 loc = int(metrics.get('loc'))
                 debug_message('Lines of code: %s' % loc)


### PR DESCRIPTION
#### The Bug:

On windows, the file path comparison returns false even when the files are exactly the same.
I narrowed the issue down to mismatching / and \ characters in the file paths.

For instance, a simple string comparison on windows like this 

```
"some/random/file" == "some/random\file" #returns false
```

As far as I know, *nix machines do not have this issue.
#### The Fix:

The paths are now normalised first before comparison.
