### PR TITLE
Python error in matcher.py

### DIFF
--- a/SublimePHPCoverage.py
+++ b/SublimePHPCoverage.py
@@ -102,6 +102,9 @@ class PhpcoverageUpdateCommand(CoverageCommand, sublime_plugin.TextCommand):
     def run(self, edit, coverage=None, **kwargs):
         filename = self.view.file_name()
 
+        if filename is None:
+            return
+
         if not self.should_include(filename):
             debug_message("Ignoring excluded file '%s'" % filename)
             return

--- a/php_coverage/mediator.py
+++ b/php_coverage/mediator.py
@@ -53,6 +53,9 @@ class ViewWatcherMediator():
         # find coverage file for the view's file
         filename = view.file_name()
 
+        if filename is None:
+            return
+
         if not self.matcher.should_include(filename):
             debug_message("Ignoring excluded file '%s'" % filename)
             return


### PR DESCRIPTION
I have installed via git the latest version: https://github.com/bradfeehan/SublimePHPCoverage/tree/479cbbd7df61f6d347772d9a5558ab4753e2857b

The configuration looks like to be correct, but here is what I see in the Sublime Text 3 console:

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 549, in run_
    return self.run(edit)
  File "~/Library/Application Support/Sublime Text 3/Packages/SublimePHPCoverage/SublimePHPCoverage.py", line 105, in run
    if not self.should_include(filename):
  File "~/Library/Application Support/Sublime Text 3/Packages/SublimePHPCoverage/php_coverage/command.py", line 55, in should_include
    return self.get_matcher().should_include(filename)
  File "~/Library/Application Support/Sublime Text 3/Packages/SublimePHPCoverage/php_coverage/matcher.py", line 18, in should_include
    return self.included(filename) and not self.excluded(filename)
  File "~/Library/Application Support/Sublime Text 3/Packages/SublimePHPCoverage/php_coverage/matcher.py", line 24, in included
    return self.match(config.include, filename)
  File "~/Library/Application Support/Sublime Text 3/Packages/SublimePHPCoverage/php_coverage/matcher.py", line 37, in match
    if re.search(pattern, string):
  File "X/re.py", line 161, in search
TypeError: expected string or buffer
```
