### PR TITLE
Update Package Control metadata to schema version 2.0.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,20 +1,16 @@
 {
-    "schema_version": "1.2",
+    "schema_version": "2.0",
+    
     "packages": [
         {
             "name": "PHP Code Coverage",
-            "description": "A plugin for Sublime Text 2 and 3, which visualises PHP code coverage data in the editor.",
-            "author": "Brad Feehan",
-            "homepage": "https://github.com/bradfeehan/SublimePHPCoverage",
-            "last_modified": "2013-06-17 00:35:22",
-            "platforms": {
-                "*": [
-                    {
-                        "version": "0.2.1",
-                        "url": "https://nodeload.github.com/bradfeehan/SublimePHPCoverage/zip/0.2.1"
-                    }
-                ]
-            }
+            "details": "https://github.com/bradfeehan/SublimePHPCoverage",
+            "releases": [
+                {
+                    "sublime_text": "*",
+                    "details": "https://github.com/bradfeehan/SublimePHPCoverage/tags"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This should resolve #20.
Explicitly states that it works with all versions of Sublime Text.
Removes metadata which does not conflict with what is pulled automatically from GitHub.
Uses Package Control's understanding of semantically versioned tags to update release data automatically from new tags (which seems to follow current practice in the repository).
